### PR TITLE
ci: 🤞 run ci against main, tags, and pr's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: 🔍 Continuous Integration
 on:
-  - pull_request
+  pull_request:
+    branches:
+      - main
+  push:
+    tags:
+    branches:
+      - main
 
 jobs:
   check:


### PR DESCRIPTION
in #257, we removed a failing CI workflow. this uncovered another issue, which is that the CI task is not configured to run when commits are pushed to main.

the yaml syntax is slightly funky, but documentation on workflows can be found here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions

this takes a swing at configuring ci so that we run our CI system when pr's are merged, and when release tags are pushed.

Refs: #257