### PR TITLE
ci: ➕ other ci checks for main, tags, and pr's

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -1,6 +1,12 @@
 name: 🛡 Dependency Security & License Audit 
 on:
-  - pull_request
+  pull_request:
+    branches:
+      - main
+  push:
+    tags:
+    branches:
+      - main
 
 jobs:
   cargo-deny:

--- a/.github/workflows/web-app-ci.yml
+++ b/.github/workflows/web-app-ci.yml
@@ -1,7 +1,12 @@
 name: 🌐 Continuous Integration
-
 on:
-  - pull_request
+  pull_request:
+    branches:
+      - main
+  push:
+    tags:
+    branches:
+      - main
 
 jobs:
   build_core_frontend:


### PR DESCRIPTION
now that we run our ci workflow against the `main` branch after merging a pr, and have confirmed that this works properly (see links below), we can perform the same change from #258 on the `audits` and `web-app-ci` workflows.

* https://github.com/banyancomputer/banyan-core/actions/runs/7134023696/job/19427955225
* https://github.com/banyancomputer/banyan-core/actions/runs/7134023696/job/19427956041

Refs: #257, #258