### PR TITLE
ci: 🧹 only lint squashed commit messages

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,6 +1,7 @@
-name: 🧹Lint Commit Messages
+name: 🧹 Lint Commit Messages
 on:
-  - pull_request
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   commitlint:


### PR DESCRIPTION
we use the `commitlint` workflow to enforce that commit messages follow the "conventional commits" format. this allows maintainers (us) to automatically generate changelogs when publishing new releases, which helps reduce the toil involved with releasing software here at Banyan Computer.

for more information about that specification, see the links below.

* <https://github.com/conventional-changelog/commitlint>
* <https://www.conventionalcommits.org/en/v1.0.0/>

this workflow has a flaw however, when taken in hand with the fact that we squash merge our pull requests: only the temporary commits in development branches are linted, rather than the squashed commits that make their way into the final git history used to generate such a changelog.

**NB:** in order for this to take effect, we will need to enable merge queues in the `banyan-core` repository. once that is done, this lint will check the commit message entered when a pr is merged, rather than enforcing process for no benefit upon developers working on features.