### PR TITLE
docs: 💘 document how to work with databases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,18 @@ generate-storage-provider-service-key:
 		&& cargo build                            \
 		&& (timeout 3s cargo run || true)         \
 	)
+
+# database administration
+# =========================================================================== #
+
+.PHONY: connect-to-core-database
+connect-to-core-database:
+	sqlite3 crates/banyan-core-service/data/server.db
+
+.PHONY: connect-to-staging-database
+connect-to-staging-database:
+	sqlite3 crates/banyan-staging-service/data/server.db
+
+.PHONY: connect-to-storage-provider-database
+connect-to-storage-provider-database:
+	sqlite3 crates/banyan-storage-provider-service/data/server.db

--- a/README.md
+++ b/README.md
@@ -146,6 +146,32 @@ cargo run
 You should now be able to open up your web-browser to
 [http://127.0.0.1:3001](http://127.0.0.1:3001), login, and use the platform.
 
+## 🔌 Connecting to the Databases
+
+It can be helpful during development to query the SQL databases for the
+core, staging, and storage provider services directly.
+
+Each of these services' databases write to their respective `data/` directory.
+The `Makefile` contains some commands to attach a sqlite prompt to each:
+
+```sh
+make connect-to-core-database
+make connect-to-staging-database
+make connect-to-storage-provider-database
+```
+
+### 💭 Helpful Commands
+
+Use these commands to list databases, indexes, and tables.
+
+* `.databases`: list names and files of attached databases
+* `.indexes`: list names of indexes
+* `.tables`: list names of tables
+* `.schema`: show the `CREATE` statements for table(s)
+
+For more information run `.help` in the sqlite prompt, or refer to the
+[Official Documentation](https://www.sqlite.org/docs.html).
+
 ## 🔒 Updating Tomb WASM
 
 In the tomb repository go to the `tomb-wasm` sub-crate. Build it with the


### PR DESCRIPTION
as part of my work on ENG-468, i found myself investigating how to (a) connect to the databases for each of the Banyan services, (b) see the tables and indexes within each database, and (c) see the schema of a particular table.

this adds documentation to the README explaining how to connect to the databases, and adds three simple makefile commands to help make this knowledge accessible and discoverable to others.