### PR TITLE
Don't set the domain on new user cookie to work around long time chrome bug (#56211)

### DIFF
--- a/crates/banyan-core-service/src/auth/oauth_callback.rs
+++ b/crates/banyan-core-service/src/auth/oauth_callback.rs
@@ -166,6 +166,7 @@ pub async fn handler(
                     .http_only(false)
                     .expires(None)
                     .same_site(SameSite::Lax)
+                    .path("/")
                     .secure(cookie_secure)
                     .finish(),
             );


### PR DESCRIPTION
Chrome isn't setting the new user cookie due to this bug: https://bugs.chromium.org/p/chromium/issues/detail?id=56211

One of the workarounds is to not set a domain. This might not work for localhost still but should for 127.0.0.1.