### PR TITLE
Restore 404s to bad api routes

### DIFF
--- a/crates/banyan-core-service/src/api/mod.rs
+++ b/crates/banyan-core-service/src/api/mod.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
 use axum::body::HttpBody;
-use axum::Router;
 use axum::response::{IntoResponse, Response};
+use axum::Router;
 use tower_http::cors::CorsLayer;
 
 mod auth;


### PR DESCRIPTION
Didn't notice this before the corrected SPA page handler that got fixed earlier. The 404's coming from the API shouldn't fallback to the SPA, but should be valid JSON responses instead.