### PR TITLE
fix: platform key fingerprint was being misrepresented as the user's

### DIFF
--- a/crates/banyan-core-service/src/api/buckets/authorization_grants.rs
+++ b/crates/banyan-core-service/src/api/buckets/authorization_grants.rs
@@ -6,10 +6,10 @@ use uuid::Uuid;
 
 use crate::app::AppState;
 use crate::auth::storage_ticket::StorageTicketBuilder;
-use crate::extractors::UserIdentity;
+use crate::extractors::ApiIdentity;
 
 pub async fn handler(
-    user_identity: UserIdentity,
+    api_id: ApiIdentity,
     State(state): State<AppState>,
     Path(bucket_id): Path<Uuid>,
 ) -> Result<Response, AuthorizationGrantError> {
@@ -18,7 +18,7 @@ pub async fn handler(
 
     let bucket_id = bucket_id.to_string();
 
-    let user_id = user_identity.id().to_string();
+    let user_id = api_id.user_id().to_string();
     let authorized_amounts = sqlx::query_as!(
         AuthorizedAmounts,
         r#"WITH current_grants AS (
@@ -49,7 +49,7 @@ pub async fn handler(
         return Err(AuthorizationGrantError::NotFound);
     }
 
-    let mut ticket_builder = StorageTicketBuilder::new(user_identity.ticket_subject());
+    let mut ticket_builder = StorageTicketBuilder::new(api_id.ticket_subject());
 
     for auth_details in authorized_amounts.into_iter() {
         ticket_builder.add_audience(auth_details.storage_host_name);

--- a/crates/banyan-core-service/src/extractors/admin_identity.rs
+++ b/crates/banyan-core-service/src/extractors/admin_identity.rs
@@ -29,19 +29,16 @@ impl AdminIdentity {
 }
 
 impl AdminIdentity {
+    pub fn email(&self) -> &str {
+        self.identity.email()
+    }
+
     pub fn session_id(&self) -> Uuid {
         self.identity.session_id()
     }
 
     pub fn user_id(&self) -> Uuid {
         self.identity.user_id()
-    }
-
-    pub fn key_fingerprint(&self) -> &str {
-        self.identity.key_fingerprint()
-    }
-    pub fn email(&self) -> &str {
-        self.identity.email()
     }
 }
 

--- a/crates/banyan-core-service/src/extractors/api_identity.rs
+++ b/crates/banyan-core-service/src/extractors/api_identity.rs
@@ -57,6 +57,10 @@ impl ApiIdentity {
     pub fn key_fingerprint(&self) -> &str {
         &self.key_fingerprint
     }
+
+    pub fn ticket_subject(&self) -> String {
+        format!("{}@{}", self.user_id(), self.key_fingerprint())
+    }
 }
 
 #[async_trait]

--- a/crates/banyan-core-service/src/extractors/mod.rs
+++ b/crates/banyan-core-service/src/extractors/mod.rs
@@ -14,6 +14,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 pub use admin_identity::AdminIdentity;
+pub use api_identity::ApiIdentity;
 pub use data_store::DataStore;
 pub use server_base::ServerBase;
 pub use session_identity::SessionIdentity;

--- a/crates/banyan-core-service/src/extractors/session_identity.rs
+++ b/crates/banyan-core-service/src/extractors/session_identity.rs
@@ -15,7 +15,6 @@ use uuid::Uuid;
 use crate::app::ServiceVerificationKey;
 use crate::auth::{LOGIN_PATH, SESSION_COOKIE_NAME};
 use crate::database::Database;
-use crate::utils::keys::fingerprint_public_key;
 
 /// Extracted identity from a request made with a server-signed JWT
 pub struct SessionIdentity {
@@ -25,8 +24,6 @@ pub struct SessionIdentity {
     email: String,
     /// The user id of the user who owns the session
     user_id: Uuid,
-    /// The hex formatted fingerprint of the API key used to sign the JWT
-    key_fingerprint: String,
 
     created_at: OffsetDateTime,
     expires_at: OffsetDateTime,
@@ -39,10 +36,6 @@ impl SessionIdentity {
 
     pub fn user_id(&self) -> Uuid {
         self.user_id
-    }
-
-    pub fn key_fingerprint(&self) -> &str {
-        &self.key_fingerprint
     }
 
     pub fn email(&self) -> &str {
@@ -132,13 +125,11 @@ where
             Uuid::parse_str(&db_session.id).map_err(SessionIdentityError::CorruptDatabaseId)?;
         let user_id = Uuid::parse_str(&db_session.user_id)
             .map_err(SessionIdentityError::CorruptDatabaseId)?;
-        let key_fingerprint = fingerprint_public_key(&verification_key);
 
         Ok(SessionIdentity {
             session_id,
             user_id,
             email: db_session.email,
-            key_fingerprint,
 
             created_at: db_session.created_at,
             expires_at: db_session.expires_at,

--- a/crates/banyan-core-service/src/extractors/user_identity.rs
+++ b/crates/banyan-core-service/src/extractors/user_identity.rs
@@ -18,17 +18,6 @@ impl UserIdentity {
             UserIdentity::Session(session) => session.user_id(),
         }
     }
-
-    pub fn key_fingerprint(&self) -> &str {
-        match &self {
-            UserIdentity::Api(api) => api.key_fingerprint(),
-            UserIdentity::Session(session) => session.key_fingerprint(),
-        }
-    }
-
-    pub fn ticket_subject(&self) -> String {
-        format!("{}@{}", self.id(), self.key_fingerprint())
-    }
 }
 
 #[async_trait]


### PR DESCRIPTION
In the big stripe PR, one of the changes I made removed a layer of abstraction from the UserIdentity extractor [here](https://github.com/banyancomputer/banyan-core/commit/b9fd77e33e474e93b2fe6b8b23ce85b61364de41#diff-99fbabeb90e6d0b43926797f5fa090d475c0868f6f09beccc36d92614b04070cR9-R51). That both revealed an issue and exposed an accidental dependency in the code:

1. The priority/order of which identity is parsed first got reversed (When both identities are present, previously the API identity would win. This swapped that to give Session identities priority)
 2. Session identities were incorrectly reporting the platform's public key as their own when they shouldn't have a valid key associated with them at all
 3. The UserIdentity was being used to enforce authentication in several places where only API keys should be used (I noticed more routes configured this way but I'll fix those in a separate PR)
 
So ultimately when we went to generate a storage authentication ticket for the current user that was authenticated both via session and API key (such as the web browser's api client), it would create a storage authorization ticket not using any public key associated with the client but instead with the platform effectively granting the platform the ability to store at the storage host instead of the client. The client never got an authorization so its requests were rejected.

* This removes the key fingerprint from the identities that expose it other than the API Identity
* Fixes the storage authorization routes so the required identity isn't ambiguous