### PR TITLE
Tighten up the api endpoints to specific identity types

### DIFF
--- a/crates/banyan-core-service/src/api/auth/create_escrowed_device.rs
+++ b/crates/banyan-core-service/src/api/auth/create_escrowed_device.rs
@@ -5,11 +5,11 @@ use jwt_simple::prelude::ES384PublicKey;
 
 use crate::api::models::ApiEscrowedKeyMaterial;
 use crate::app::AppState;
-use crate::extractors::UserIdentity;
+use crate::extractors::SessionIdentity;
 use crate::utils::keys::fingerprint_public_key;
 
 pub async fn handler(
-    user_identity: UserIdentity,
+    session_id: SessionIdentity,
     State(state): State<AppState>,
     Json(request): Json<ApiEscrowedKeyMaterial>,
 ) -> Result<Response, CreateEscrowedDeviceError> {
@@ -23,7 +23,7 @@ pub async fn handler(
         .map_err(CreateEscrowedDeviceError::InvalidPublicKey)?;
     let device_api_key_fingerprint = fingerprint_public_key(&public_device_api_key);
 
-    let user_id = user_identity.id().to_string();
+    let user_id = session_id.user_id().to_string();
     let encrypted_private_key_material = request.encrypted_private_key_material;
     let pass_key_salt = request.pass_key_salt;
 

--- a/crates/banyan-core-service/src/api/blocks/locate.rs
+++ b/crates/banyan-core-service/src/api/blocks/locate.rs
@@ -9,20 +9,20 @@ use cid::multibase::Base;
 use cid::Cid;
 
 use crate::app::AppState;
-use crate::extractors::UserIdentity;
+use crate::extractors::ApiIdentity;
 
 const NA_LABEL: &str = "NA";
 
 pub type LocationRequest = Vec<String>;
 
 pub async fn handler(
-    user_identity: UserIdentity,
+    api_id: ApiIdentity,
     State(state): State<AppState>,
     Json(request): Json<LocationRequest>,
 ) -> Result<Response, BlockLocationError> {
     let database = state.database();
 
-    let user_id = user_identity.id().to_string();
+    let user_id = api_id.user_id().to_string();
     let mut result_map: HashMap<String, Vec<String>> = HashMap::new();
 
     for original_cid in request {

--- a/crates/banyan-core-service/src/api/buckets/create_bucket.rs
+++ b/crates/banyan-core-service/src/api/buckets/create_bucket.rs
@@ -8,11 +8,11 @@ use validify::{Validate, Validify};
 
 use crate::app::AppState;
 use crate::database::models::{Bucket, BucketKey, BucketType, StorageClass};
-use crate::extractors::UserIdentity;
+use crate::extractors::ApiIdentity;
 use crate::utils::keys::fingerprint_public_key;
 
 pub async fn handler(
-    user_identity: UserIdentity,
+    api_id: ApiIdentity,
     State(state): State<AppState>,
     Json(request): Json<CreateBucketRequest>,
 ) -> Result<Response, CreateBucketError> {
@@ -27,7 +27,7 @@ pub async fn handler(
 
     let now = OffsetDateTime::now_utc();
 
-    let user_id = user_identity.id().to_string();
+    let user_id = api_id.user_id().to_string();
     let bucket_id = sqlx::query_scalar!(
         r#"INSERT INTO buckets (user_id, name, type, storage_class, updated_at)
                VALUES ($1, $2, $3, $4, $5)

--- a/crates/banyan-core-service/src/api/buckets/metadata/pull_metadata.rs
+++ b/crates/banyan-core-service/src/api/buckets/metadata/pull_metadata.rs
@@ -8,10 +8,10 @@ use object_store::ObjectStore;
 use uuid::Uuid;
 
 use crate::app::AppState;
-use crate::extractors::{DataStore, UserIdentity};
+use crate::extractors::{ApiIdentity, DataStore};
 
 pub async fn handler(
-    user_identity: UserIdentity,
+    api_id: ApiIdentity,
     store: DataStore,
     Path((bucket_id, metadata_id)): Path<(Uuid, Uuid)>,
     State(state): State<AppState>,
@@ -21,7 +21,7 @@ pub async fn handler(
     let db_bucket_id = bucket_id.to_string();
     let db_metadata_id = metadata_id.to_string();
 
-    let user_id = user_identity.id().to_string();
+    let user_id = api_id.user_id().to_string();
     let authorized_bucket_data = sqlx::query_as!(
         PullBucketData,
         r#"SELECT m.bucket_id, m.id as metadata_id FROM metadata AS m

--- a/crates/banyan-core-service/src/api/subscriptions/manage_subscription.rs
+++ b/crates/banyan-core-service/src/api/subscriptions/manage_subscription.rs
@@ -4,10 +4,10 @@ use axum::response::{IntoResponse, Response};
 
 use crate::app::{AppState, StripeHelperError};
 use crate::database::models::User;
-use crate::extractors::{ServerBase, UserIdentity};
+use crate::extractors::{ServerBase, SessionIdentity};
 
 pub async fn handler(
-    user_id: UserIdentity,
+    session_id: SessionIdentity,
     ServerBase(host_url): ServerBase,
     State(state): State<AppState>,
 ) -> Result<Response, ManageSubscriptionError> {
@@ -19,7 +19,7 @@ pub async fn handler(
         None => return Err(ManageSubscriptionError::NoStripeHelper),
     };
 
-    let user_id = user_id.id().to_string();
+    let user_id = session_id.user_id().to_string();
     let current_user = User::by_id(&mut conn, &user_id).await?;
 
     let stripe_customer_id = match &current_user.stripe_customer_id {

--- a/crates/banyan-core-service/src/api/subscriptions/session_returns.rs
+++ b/crates/banyan-core-service/src/api/subscriptions/session_returns.rs
@@ -3,14 +3,14 @@ use axum::response::{IntoResponse, Redirect, Response};
 
 use crate::app::AppState;
 use crate::database::models::StripeCheckoutSession;
-use crate::extractors::UserIdentity;
+use crate::extractors::SessionIdentity;
 
 pub async fn cancel_redirect() -> Response {
     Redirect::to("/").into_response()
 }
 
 pub async fn success_redirect(
-    user_id: UserIdentity,
+    session_id: SessionIdentity,
     State(state): State<AppState>,
     Path(checkout_session_id): Path<String>,
 ) -> Response {
@@ -22,7 +22,7 @@ pub async fn success_redirect(
         Err(_) => return redirect,
     };
 
-    let user_id = user_id.id().to_string();
+    let user_id = session_id.user_id().to_string();
 
     let mut checkout_session =
         match StripeCheckoutSession::find_by_stripe_id(&mut conn, &user_id, &checkout_session_id)

--- a/crates/banyan-core-service/src/api/users/current_escrowed_device.rs
+++ b/crates/banyan-core-service/src/api/users/current_escrowed_device.rs
@@ -5,14 +5,14 @@ use http::StatusCode;
 use crate::api::models::ApiEscrowedKeyMaterial;
 use crate::app::AppState;
 use crate::database::models::EscrowedDevice;
-use crate::extractors::UserIdentity;
+use crate::extractors::SessionIdentity;
 
 pub async fn handler(
-    user_identity: UserIdentity,
+    session_id: SessionIdentity,
     State(state): State<AppState>,
 ) -> Result<Response, ReadEscrowedDeviceError> {
     let database = state.database();
-    let user_id = user_identity.id().to_string();
+    let user_id = session_id.user_id().to_string();
     let escrowed_device = sqlx::query_as!(
         EscrowedDevice,
         "SELECT * FROM escrowed_devices WHERE user_id = $1;",


### PR DESCRIPTION
This adjusts a few API endpoints that don't make sense to be called from the perspective of an API or session identity.