### PR TITLE
feat: Re-enable Mandatory CI Checks

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -34,8 +34,22 @@ branches:
       required_status_checks:
         strict: true
         contexts:
-          - "rust"
-          - "node"
+          - "ci / rust / build"
+          - "ci / rust / test"
+          - "ci / rust / format"
+          - "ci / rust / audit"
+          - "ci / node (banyan-core-service, admin_frontend) / build"
+          - "ci / node (banyan-core-service, admin_frontend) / test"
+          - "ci / node (banyan-core-service, admin_frontend) / audit"
+          - "ci / node (banyan-core-service, frontend) / build"
+          - "ci / node (banyan-core-service, frontend) / test"
+          - "ci / node (banyan-core-service, frontend) / audit"
+          - "ci / node (banyan-staging-service, admin_frontend) / build"
+          - "ci / node (banyan-staging-service, admin_frontend) / test"
+          - "ci / node (banyan-staging-service, admin_frontend) / audit"
+          - "ci / node (banyan-storage-provider-service, frontend) / build"
+          - "ci / node (banyan-storage-provider-service, frontend) / test"
+          - "ci / node (banyan-storage-provider-service, frontend) / audit"
 
       # Required to to be present due too a limitation in GitHub's GraphQL API
       restrictions: null

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   image:
     runs-on: ubuntu-latest
+    if: github.ref_name == 'main'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
I don't know if this will accomplish anything until it is merged, it seems that it always uses the version in `main` even for PRs. If that's the case, we won't know if this is set up properly until we merge.

It makes sense to mandate rust build/test/audit/format and node build/test/audit, but we _could_ skip the Docker step if we really wanted to. In our current configuration, we only build Docker images if build/test/audit/format pass for Node and Rust, since we don't want to produce Docker images that are failing these. If we didn't care about tests/audits passing, we could make Docker image tasks start concurrently with everything else, and we could potentially not mandate passing Docker image builds to make PRs mergeable sooner, but it's obviously a trade-off.