### PR TITLE
Revert "feat: Re-enable Mandatory CI Checks (#478)"

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -34,22 +34,8 @@ branches:
       required_status_checks:
         strict: true
         contexts:
-          - "ci / rust / build"
-          - "ci / rust / test"
-          - "ci / rust / format"
-          - "ci / rust / audit"
-          - "ci / node (banyan-core-service, admin_frontend) / build"
-          - "ci / node (banyan-core-service, admin_frontend) / test"
-          - "ci / node (banyan-core-service, admin_frontend) / audit"
-          - "ci / node (banyan-core-service, frontend) / build"
-          - "ci / node (banyan-core-service, frontend) / test"
-          - "ci / node (banyan-core-service, frontend) / audit"
-          - "ci / node (banyan-staging-service, admin_frontend) / build"
-          - "ci / node (banyan-staging-service, admin_frontend) / test"
-          - "ci / node (banyan-staging-service, admin_frontend) / audit"
-          - "ci / node (banyan-storage-provider-service, frontend) / build"
-          - "ci / node (banyan-storage-provider-service, frontend) / test"
-          - "ci / node (banyan-storage-provider-service, frontend) / audit"
+          - "rust"
+          - "node"
 
       # Required to to be present due too a limitation in GitHub's GraphQL API
       restrictions: null

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   image:
     runs-on: ubuntu-latest
-    if: github.ref_name == 'main'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This reverts commit d2eb0097a24b5ccccf58bbb26e7901d7dc62a138.

The change breaks CI required checks for all PRs regardless of passing checks. We probably do not have the format right, but docs are difficult to find.